### PR TITLE
feat: record live transaction history

### DIFF
--- a/client/src/components/PinModal.tsx
+++ b/client/src/components/PinModal.tsx
@@ -48,7 +48,9 @@ export default function PinModal({
   const handleFingerprint = async () => {
     try {
       // Get the authentication challenge from your server
-      const resp = await fetch("/api/webauthn/auth-options");
+      const resp = await fetch("/api/webauthn/auth-options", {
+        credentials: "include",
+      });
       const options = await resp.json();
 
       // Prompt the user to scan their fingerprint/face
@@ -58,6 +60,7 @@ export default function PinModal({
       const verificationResp = await fetch("/api/webauthn/auth", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify(assertion),
       });
 

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -45,7 +45,9 @@ export function ProfilePage() {
   const handleRegisterFingerprint = async () => {
     try {
       // Note: You will need to create this endpoint on your server
-      const resp = await fetch("/api/webauthn/register-options");
+      const resp = await fetch("/api/webauthn/register-options", {
+        credentials: "include",
+      });
       const options = await resp.json();
 
       const attestation = await startRegistration(options);
@@ -56,6 +58,7 @@ export function ProfilePage() {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: "include",
         body: JSON.stringify(attestation),
       });
 

--- a/client/src/pages/TopUpPage.tsx
+++ b/client/src/pages/TopUpPage.tsx
@@ -27,6 +27,7 @@ export function TopUpPage() {
       // 👇 THIS IS THE CHANGED LINE
       // Actively refetch the user data and wait for it to finish.
       await queryClient.refetchQueries({ queryKey: ["/api/auth/user"] });
+      await queryClient.refetchQueries({ queryKey: ["/api/transactions"] });
 
       // Now that the data is fresh, go back to the home page.
       setLocation("/home");

--- a/client/src/pages/TransactionHistoryPage.tsx
+++ b/client/src/pages/TransactionHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import {
   ArrowLeft,
@@ -10,59 +11,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Transaction } from "@/components/TransactionHistory";
-
-// ... (mock data remains the same)
-const allMockTransactions: Transaction[] = [
-  {
-    id: "1",
-    type: "debit",
-    description: "Coca-Cola Purchase",
-    amount: 150.0,
-    date: "29 Aug, 2025",
-  },
-  {
-    id: "2",
-    type: "credit",
-    description: "Wallet Top-up",
-    amount: 1000.0,
-    date: "28 Aug, 2025",
-  },
-  {
-    id: "3",
-    type: "debit",
-    description: "Fanta Purchase",
-    amount: 150.0,
-    date: "27 Aug, 2025",
-  },
-  {
-    id: "4",
-    type: "debit",
-    description: "Sprite Purchase",
-    amount: 150.0,
-    date: "26 Aug, 2025",
-  },
-  {
-    id: "5",
-    type: "credit",
-    description: "Wallet Top-up",
-    amount: 500.0,
-    date: "25 Aug, 2025",
-  },
-  {
-    id: "6",
-    type: "debit",
-    description: "Water Purchase",
-    amount: 100.0,
-    date: "24 Aug, 2025",
-  },
-  {
-    id: "7",
-    type: "debit",
-    description: "Pepsi Purchase",
-    amount: 150.0,
-    date: "23 Aug, 2025",
-  },
-];
 
 const TransactionItem = ({
   tx,
@@ -106,8 +54,23 @@ export default function TransactionHistoryPage({
   setIsBalanceVisible,
 }: TransactionHistoryPageProps) {
   const [filter, setFilter] = useState("all");
+  const { data: rawTransactions = [] } = useQuery<any[]>({
+    queryKey: ["/api/transactions"],
+  });
 
-  const filteredTransactions = allMockTransactions.filter((tx) => {
+  const allTransactions: Transaction[] = rawTransactions.map((tx) => ({
+    id: tx.id,
+    type: tx.type,
+    description: tx.description,
+    amount: parseFloat(tx.amount),
+    date: new Date(tx.createdAt).toLocaleDateString("en-US", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }),
+  }));
+
+  const filteredTransactions = allTransactions.filter((tx) => {
     if (filter === "all") return true;
     return tx.type === filter;
   });

--- a/server/db.ts
+++ b/server/db.ts
@@ -12,5 +12,19 @@ if (!process.env.DATABASE_URL) {
 // Create a new postgres client with the connection string.
 const client = postgres(process.env.DATABASE_URL);
 
+// Ensure the transactions table exists so wallet activity can be logged even
+// if migrations haven't been run yet. This mirrors the schema definition in
+// `shared/schema.ts` and is safe to run multiple times.
+await client`
+  CREATE TABLE IF NOT EXISTS "transactions" (
+    "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "user_id" varchar NOT NULL REFERENCES "users"("id"),
+    "type" varchar NOT NULL,
+    "description" text NOT NULL,
+    "amount" numeric(10, 2) NOT NULL,
+    "created_at" timestamp DEFAULT now()
+  );
+`;
+
 // Initialize Drizzle with the new client and your schema.
 export const db = drizzle(client, { schema });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -80,6 +80,19 @@ export const orders = pgTable("orders", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+export const transactions = pgTable("transactions", {
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  userId: varchar("user_id")
+    .notNull()
+    .references(() => users.id),
+  type: varchar("type").notNull(), // 'credit' or 'debit'
+  description: text("description").notNull(),
+  amount: decimal("amount", { precision: 10, scale: 2 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 export const authenticators = pgTable("authenticators", {
   id: varchar("id").primaryKey(),
   userId: varchar("user_id")
@@ -113,3 +126,5 @@ export type InsertOrder = z.infer<typeof insertOrderSchema>;
 export type Order = typeof orders.$inferSelect;
 export type InsertWallet = typeof wallets.$inferInsert;
 export type Wallet = typeof wallets.$inferSelect;
+export type InsertTransaction = typeof transactions.$inferInsert;
+export type Transaction = typeof transactions.$inferSelect;


### PR DESCRIPTION
## Summary
- add transactions table and storage helpers
- log wallet top-ups and drink purchases
- fetch and display real transaction history in the UI
- ensure the transactions table exists on startup to prevent 500 errors
- persist WebAuthn challenges in Postgres-backed sessions so fingerprint auth works across requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run check`
- `npm run db:push` *(fails: DATABASE_URL, ensure the database is provisioned)*

------
https://chatgpt.com/codex/tasks/task_e_68c7282a5bdc83289e1a4f7f90c7213b